### PR TITLE
Fix vectorstore path

### DIFF
--- a/backend/app/dataService/README.md
+++ b/backend/app/dataService/README.md
@@ -45,8 +45,8 @@ You can use `preprocess.py` to process either a folder of PDFs or a single PDF f
    --figure_dir <path_to_figure_output_folder> \
    --table_dir <path_to_table_output_folder> \
    --meta_dir <path_to_meta_output_folder> \
-   --vectorstore_dir <path_to_vectorstore_output_folder>
-   ```
+ --vectorstore_dir <path_to_vectorstore_output_folder>
+  ```
 
 2. Processing a folder of PDFs:
    ```python
@@ -56,8 +56,11 @@ You can use `preprocess.py` to process either a folder of PDFs or a single PDF f
    --table_dir <path_to_table_output_folder> \
    --meta_dir <path_to_meta_output_folder> \
    --vectorstore_dir <path_to_vectorstore_output_folder>
-   ```
+  ```
 Add the `--fast` flag for faster, non-LLM-based table extraction. For more options, run python preprocess.py --help.
+
+Make sure the `vectorstore_dir` value in your `config.yml` matches the directory
+used during preprocessing. `DataService` loads vector stores from this location.
 
 ### Using dataService.py
 

--- a/backend/app/dataService/dataService.py
+++ b/backend/app/dataService/dataService.py
@@ -62,6 +62,7 @@ class DataService(object):
 
         self.paper_folder = GV.data_dir
         self.table_folder = GV.table_dir
+        self.vectorstore_folder = GV.vectorstore_dir
 
         self.load_flag = True # load precomputed vectorstore and docstore
         self.vectorstore_loaded = False
@@ -88,8 +89,8 @@ class DataService(object):
         retrievers = {}
         for pdf_file in os.listdir(data_folder):
             if pdf_file.endswith(".pdf"):
-                vectorstore_path = os.path.join(data_folder, "vectorstore", pdf_file.split(".")[0], "vector_index")
-                db_path = os.path.join(data_folder, "vectorstore", pdf_file.split(".")[0], pdf_file.split(".")[0] + ".pickle")
+                vectorstore_path = os.path.join(self.vectorstore_folder, pdf_file.split(".")[0], "vector_index")
+                db_path = os.path.join(self.vectorstore_folder, pdf_file.split(".")[0], pdf_file.split(".")[0] + ".pickle")
                 if load_flag:
                     embedding_model = AzureOpenAIEmbeddings(
                         azure_endpoint=GV.azure_openai_endpoint,


### PR DESCRIPTION
## Summary
- load vectorstores from the configured `vectorstore_dir`
- document how `vectorstore_dir` must match the preprocessing output

## Testing
- `python -m py_compile app/dataService/dataService.py`
- `python -m py_compile app/dataService/globalVariable.py app/dataService/preprocess.py`

------
https://chatgpt.com/codex/tasks/task_e_6848dc4b8d6c8325b989fab69c70fea2