### PR TITLE
Fix table/figure tab data loading

### DIFF
--- a/backend/app/routes/api.py
+++ b/backend/app/routes/api.py
@@ -134,7 +134,8 @@ def extract_figure_from_pdf():
             # update figure_url to serve through the API
             for fig in figs:
                 if "figure_url" in fig:
-                    figure_name = fig["figure_url"].split("/")[-1]
+                    # handle absolute paths from any OS
+                    figure_name = os.path.basename(fig["figure_url"])
                     fig["figure_url"] = url_for(
                         "api.serve_image",
                         filename=figure_name,

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -971,7 +971,7 @@ export default {
     displayPDFTable(filename) {
       console.log("displayPDFTable", filename);
 
-      service.extract_table_from_pdf([{ "name": filename }], this.openai_key, tables => {
+      service.extract_table_from_pdf([{ "name": filename }], tables => {
         console.log("extract_table_from_pdf: ", tables[0], typeof tables[0], typeof tables);
         this.tableLists = tables[0];
         if (tables[0] && tables[0].length > 0 && !this.paperInfoList.includes("Table")) {
@@ -982,7 +982,7 @@ export default {
     displayPDFMeta(filename) {
       console.log("displayPDFMeta", filename);
 
-      service.extract_meta_from_pdf([{ "name": filename }], this.openai_key, meta => {
+      service.extract_meta_from_pdf([{ "name": filename }], meta => {
         // console.log("extract_meta_from_pdf: ", meta[0]);
         this.metaInfo = meta[0];
       });
@@ -990,7 +990,7 @@ export default {
     displayPDFFigure(filename) {
       console.log("displayPDFFigure", filename);
 
-      service.extract_figure_from_pdf([{ "name": filename }], this.openai_key, figures => {
+      service.extract_figure_from_pdf([{ "name": filename }], figures => {
         console.log("extract_figure_from_pdf: ", figures[0]);
         this.figLists = figures[0];
         if (figures[0] && figures[0].length > 0 && !this.paperInfoList.includes("Figure")) {


### PR DESCRIPTION
## Summary
- load table/figure/meta info without sending a non-existent API key

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68531ea4726c8325b19ef6902d19b0de